### PR TITLE
changes in typeDefs 

### DIFF
--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -14,11 +14,11 @@ const typeDefs = gql`
   type Art {
     _id: ID!
     title: String!
-    year: Date
+    year: String
     description: String!
     imageUrl: String!
-    price: Number!
-    createdAt: Date
+    price: Int!
+    createdAt: String
     artist: [Artist]
   }
 
@@ -35,14 +35,21 @@ const typeDefs = gql`
     singleArtwork(artId: ID!): Artist
     users: [User]
     user(username: String!): User
-
   }
 
   type Mutation {
-    addArtist(artistName: String!, art: [Art]): Artist
-    addArt(artistId: ID!, title: String!, year: Date, description: String!, imageUrl: String!, price: String!): Artist
+    addArtist(artistName: String!, art: [String]): Artist
+    addArt(
+      artistId: ID!
+      title: String!
+      year: String
+      description: String!
+      imageUrl: String!
+      price: String!
+    ): Artist
     removeArtist(artistId: ID!): Artist
     removeArt(artistId: ID!, artId: ID!): Artist
+    addUser(username: String!, email: String!, password: String!): User
   }
 `;
 


### PR DESCRIPTION
added addUser mutation and changed art in addArtist mutation from [Art] to [String]

I was getting an error that art in the addArtist mutation needed to be an Input Type but was "getting [Art]" instead so I changed it to [String]. Wasn't 100% sure what it should be changed to since the art array in the artistSchema has a type: mongoose.Schema.Types.ObjectId. Not totally sure which input type would correspond to that. 